### PR TITLE
Directly invoke black and flake8 in lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         name: Black
         description: Formats python files with Black.
         language: system
-        entry: poetry run task format
+        entry: black .
         require_serial: true
         pass_filenames: false
 
@@ -28,6 +28,6 @@ repos:
         name: Flake8
         description: Lint using flake8.
         language: system
-        entry: poetry run flake8
+        entry: flake8
         require_serial: true
         pass_filenames: false


### PR DESCRIPTION
`pre-commit` requires you to activate the venv anyway so there's no point in invoking lint with `poetry run`. This should also hopefully fix `pre-commit.ci` failing on every PR as it can't find `poetry`.