### PR TITLE
repo-dispatch action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Trigger repository_dispatch event on gamingrealm-frontend
         env:
-          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          GITHUB_PAT: ${{ secrets.GH_PAT }}
         run: |
           curl -L \
             -X POST \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,3 +11,18 @@ jobs:
           WATCHTOWER_TOKEN: ${{ secrets.WATCHTOWER_TOKEN }}
         run: |
           curl -H "Authorization: Bearer $WATCHTOWER_TOKEN" https://watchtower.lnkshrt.xyz/v1/update
+  trigger_frontend_action:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Trigger repository_dispatch event on gamingrealm-frontend
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_PAT" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/idkbrowby/gamingrealm-frontend/dispatches \
+            -d '{"event_type":"on-backend-deploy", "client_payload": {}}'


### PR DESCRIPTION
Adds a job to the `deploy` action that runs after watchtower is triggered. This job triggers a `repository_dispatch` event
on [gamingrealm-frontend](https://github.com/idkbrowby/gaminrealm-frontend) that is used there to run the OpenAPI type generator in CI.