### PR TITLE
fix: skip cursor entry in each page

### DIFF
--- a/src/backend/paginate_db.py
+++ b/src/backend/paginate_db.py
@@ -41,7 +41,9 @@ async def paginate(
     """
     if cursor_id:
         logger.info(f"Making page query: {model}, page size={page_size}")
-        data = await model.prisma().find_many(take=page_size, cursor={"id": cursor_id}, **kwargs)
+        data = await model.prisma().find_many(
+            take=page_size, cursor={"id": cursor_id}, skip=1, **kwargs
+        )
     else:
         data = await model.prisma().find_many(take=page_size, **kwargs)
     if f:


### PR DESCRIPTION
We were sending the last post in each page as the first post in the next page - this PR skips this duplicate post.
https://www.prisma.io/docs/concepts/components/prisma-client/pagination#do-i-always-have-to-skip-1