### PR TITLE
fix: explicitly invoke black via poetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
         name: Black
         description: Formats python files with Black.
         language: system
-        entry: black .
+        entry: poetry run black .
         require_serial: true
         pass_filenames: false


### PR DESCRIPTION
Previously it was assumed that we were making commits after running `poetry shell` or had `black` installed on our system globally - if both of these weren't true attempting to commit would fail telling "executable black not found". This PR explicitly runs the `black` that's installed as a dev-dep of this project.