### PR TITLE
feat: Disable uvicorn auto-reload in production

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
+extra_options=""
+if [[ $DEBUG != "false" ]]; then
+    extra_options="--reload --reload-dir ./src"
+fi
+
 poetry run prisma migrate deploy
-poetry run uvicorn src.backend.app:app --host 0.0.0.0 --reload --reload-dir ./src
+poetry run uvicorn src.backend.app:app --host 0.0.0.0 $extra_options


### PR DESCRIPTION
Uvicorn's `--reload` flag is meant to be used in development.